### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var loaderUtils = require('loader-utils');
 var path = require('path');
 
-var templateUrlRegex = /templateUrl\s*:\s*['"`](.*?)['"`]\s*([,}\n])/gm;
+var templateUrlRegex = /template(Url)?\s*:\s*['"`]((?!\<).*?)['"`]\s*([,}\n])/gm;
 
 module.exports = function(source) {
   var context = this;


### PR DESCRIPTION
Allow not only `templateUrl` but and `template` ex. https://regex101.com/r/LdqQun/1
Some angular plug-ins using only `template`

An please release a new version